### PR TITLE
gather event data passed by subclasses

### DIFF
--- a/notebook/base/handlers.py
+++ b/notebook/base/handlers.py
@@ -314,6 +314,11 @@ class IPythonHandler(AuthenticatedHandler):
         """Whether to set Access-Control-Allow-Credentials"""
         return self.settings.get('allow_credentials', False)
     
+    def get_event_data(self, new_event_data):
+        """Return global event data updated with new event data."""
+        new_event_data.update(self.settings.get('event_data'))
+        return new_event_data
+
     def set_default_headers(self):
         """Add CORS headers, if defined"""
         super(IPythonHandler, self).set_default_headers()

--- a/notebook/event-schemas/contentsmanager-actions/v1.yaml
+++ b/notebook/event-schemas/contentsmanager-actions/v1.yaml
@@ -77,3 +77,8 @@ properties:
     type: string
     description: |
         Source path of an operation when action is 'copy' or 'rename'
+
+  username: 
+    type: string
+    description: |
+        Name of the user whose server this action was performed on.

--- a/notebook/notebookapp.py
+++ b/notebook/notebookapp.py
@@ -1314,6 +1314,16 @@ class NotebookApp(JupyterApp):
          is not available.
          """))
 
+    event_data = Dict(
+        {},
+        help=_("""Add extra data that should be emitted by all events.
+
+        This is not configurable by users. Subclasses of this class 
+        should replace this trait.
+        """),
+        config=False,
+    )
+
     def parse_command_line(self, argv=None):
         super(NotebookApp, self).parse_command_line(argv)
 
@@ -1394,6 +1404,7 @@ class NotebookApp(JupyterApp):
         self.tornado_settings['cookie_options'] = self.cookie_options
         self.tornado_settings['get_secure_cookie_kwargs'] = self.get_secure_cookie_kwargs
         self.tornado_settings['token'] = self.token
+        self.tornado_settings['event_data'] = self.event_data
 
         # ensure default_url starts with base_url
         if not self.default_url.startswith(self.base_url):

--- a/notebook/services/contents/handlers.py
+++ b/notebook/services/contents/handlers.py
@@ -113,9 +113,10 @@ class ContentsHandler(APIHandler):
         ))
         validate_model(model, expect_content=content)
         self._finish_model(model, location=False)
+
         self.eventlog.record_event(
             eventlogging_schema_fqn('contentsmanager-actions'), 1,
-            { 'action': 'get', 'path': model['path'] }
+            self.get_event_data({ 'action': 'get', 'path': model['path'] })
         )
 
     @web.authenticated
@@ -131,11 +132,14 @@ class ContentsHandler(APIHandler):
         validate_model(model, expect_content=False)
         self._finish_model(model)
         self.log.info(model)
+
         self.eventlog.record_event(
             eventlogging_schema_fqn('contentsmanager-actions'), 1,
             # FIXME: 'path' always has a leading slash, while model['path'] does not.
             # What to do here for source_path? path munge manually? Eww
-            { 'action': 'rename', 'path': model['path'], 'source_path': path }
+            self.get_event_data(
+                { 'action': 'rename', 'path': model['path'], 'source_path': path }
+            )
         )
     
     @gen.coroutine
@@ -149,9 +153,12 @@ class ContentsHandler(APIHandler):
         self.set_status(201)
         validate_model(model, expect_content=False)
         self._finish_model(model)
+        
         self.eventlog.record_event(
             eventlogging_schema_fqn('contentsmanager-actions'), 1,
-            { 'action': 'copy', 'path': model['path'], 'source_path': copy_from }
+            self.get_event_data(
+                { 'action': 'copy', 'path': model['path'], 'source_path': copy_from }
+            )
         )
 
     @gen.coroutine
@@ -165,7 +172,7 @@ class ContentsHandler(APIHandler):
 
         self.eventlog.record_event(
             eventlogging_schema_fqn('contentsmanager-actions'), 1,
-            { 'action': 'upload', 'path': model['path'] }
+            self.get_event_data({ 'action': 'upload', 'path': model['path'] })
         )
     
     @gen.coroutine
@@ -180,7 +187,7 @@ class ContentsHandler(APIHandler):
         self.eventlog.record_event(
             eventlogging_schema_fqn('contentsmanager-actions'), 1,
             # Set path to path of created object, not directory it was created in
-            { 'action': 'create', 'path': model['path'] }
+            self.get_event_data({ 'action': 'create', 'path': model['path'] })
         )
     
     @gen.coroutine
@@ -195,7 +202,7 @@ class ContentsHandler(APIHandler):
 
         self.eventlog.record_event(
             eventlogging_schema_fqn('contentsmanager-actions'), 1,
-            { 'action': 'save', 'path': model['path'] }
+            self.get_event_data({ 'action': 'save', 'path': model['path'] })
         )
 
     @web.authenticated
@@ -269,9 +276,11 @@ class ContentsHandler(APIHandler):
         yield maybe_future(cm.delete(path))
         self.set_status(204)
         self.finish()
+
+        # Emit event.
         self.eventlog.record_event(
             eventlogging_schema_fqn('contentsmanager-actions'), 1,
-            { 'action': 'delete', 'path': path }
+            self.get_event_data({ 'action': 'delete', 'path': path })
         )
 
 


### PR DESCRIPTION
This provides a way for `NotebookApp` subclasses to add extra data to all events being emitted. The immediate use-case is adding user information to the Single-user notebook server in JupyterHub.